### PR TITLE
fix(Invoice): Denormalize currency only when creating, preserve when updating

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -367,11 +367,16 @@ class Invoice extends Model implements Attachable
     public function denormalize(): static
     {
         $pdfInvoice = $this->toPdfInvoice();
-        $this->currency = $pdfInvoice->getCurrency();
+
         $this->subtotal_amount = $pdfInvoice->subTotalAmount();
         $this->discount_amount = $pdfInvoice->totalDiscountAmount();
         $this->tax_amount = $pdfInvoice->totalTaxAmount();
         $this->total_amount = $pdfInvoice->totalAmount();
+
+        // If no currency is set yet (new invoice), then get it from items
+        if (! $this->currency) {
+            $this->currency = $pdfInvoice->getCurrency();
+        }
 
         return $this;
     }


### PR DESCRIPTION
- [x] Fix

**Description**

Currently when you create a new invoice with invoice items, Invoice::currency() will be resolved from the first invoice item, which is expected. The problem arises when you try to update your Invoice and InvoiceItem(s). First Invoice::update() will trigger denormalization where it would take currency from the OLD first invoice item, after that invoice items are going to be updated with the correct currency while the Invoice will have the old currency.

@QuentinGab Please consider that we can set Invoice currency from InvoiteItem::booted() static::creating and static::updating. I am happy to make those changes when needed.