### PR TITLE
Fix percentage formatting: use 0 as default instead of 1

### DIFF
--- a/src/Concerns/FormatForPdf.php
+++ b/src/Concerns/FormatForPdf.php
@@ -21,7 +21,7 @@ trait FormatForPdf
             return null;
         }
 
-        $percentage = ($percentage > 1) ? ($percentage / 100) : $percentage;
+        $percentage = ($percentage > 0) ? ($percentage / 100) : $percentage;
 
         $formatter = new NumberFormatter($locale ?? App::getLocale(), NumberFormatter::PERCENT);
 


### PR DESCRIPTION
Previously, the formatPercentage method used 1 as the default value, which caused percentages like 0% to be incorrectly converted to 1%. Changed default to 0 to correctly handle 0% values.

<img width="1238" height="399" alt="image" src="https://github.com/user-attachments/assets/1ab9d625-dacd-419b-8313-ca61d80f421e" />
<img width="547" height="546" alt="image" src="https://github.com/user-attachments/assets/907329d4-3a0d-426a-8056-8f9e4020528c" />

<img width="1280" height="367" alt="image" src="https://github.com/user-attachments/assets/c4e6fbe4-5a75-4732-8eaf-c27fdf6217d2" />